### PR TITLE
Mocking Zustand for testing

### DIFF
--- a/__mocks__/vitest-env.d.ts
+++ b/__mocks__/vitest-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="vitest/globals" />

--- a/__mocks__/zustand.ts
+++ b/__mocks__/zustand.ts
@@ -1,0 +1,55 @@
+import * as zustand from 'zustand'
+import { act } from '@testing-library/react'
+
+const { create: actualCreate, createStore: actualCreateStore } =
+  await vi.importActual<typeof zustand>('zustand')
+
+// a variable to hold reset functions for all stores declared in the app
+export const storeResetFns = new Set<() => void>()
+
+const createUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
+  const store = actualCreate(stateCreator)
+  const initialState = store.getState()
+  storeResetFns.add(() => {
+    store.setState(initialState, true)
+  })
+  return store
+}
+
+// when creating a store, we get its initial state, create a reset function and add it in the set
+export const create = (<T>(stateCreator: zustand.StateCreator<T>) => {
+  console.log('zustand create mock')
+
+  // to support curried version of create
+  return typeof stateCreator === 'function'
+    ? createUncurried(stateCreator)
+    : createUncurried
+}) as typeof zustand.create
+
+const createStoreUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
+  const store = actualCreateStore(stateCreator)
+  const initialState = store.getState()
+  storeResetFns.add(() => {
+    store.setState(initialState, true)
+  })
+  return store
+}
+
+// when creating a store, we get its initial state, create a reset function and add it in the set
+export const createStore = (<T>(stateCreator: zustand.StateCreator<T>) => {
+  console.log('zustand createStore mock')
+
+  // to support curried version of createStore
+  return typeof stateCreator === 'function'
+    ? createStoreUncurried(stateCreator)
+    : createStoreUncurried
+}) as typeof zustand.createStore
+
+// reset all stores after each test run
+afterEach(() => {
+  act(() => {
+    storeResetFns.forEach((resetFn) => {
+      resetFn()
+    })
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,10 @@ import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 
+// Mock Zustand
+// @see https://docs.pmnd.rs/zustand/guides/testing#vitest
+vi.mock('zustand')
+
 afterEach(() => {
   cleanup()
 })


### PR DESCRIPTION
# Description

This change follows the code outlined in [Zustand Testing Guide w/ Vitest](https://docs.pmnd.rs/zustand/guides/testing#vitest).

Two new mock functions, `create` and `createStore`, are added in the `__mocks__/zustand.ts` file. These functions mimic the behavior of the actual `create` and `createStore` functions from Zustand, but with an additional feature: they store the initial state of the store and provide a reset function to revert the store to its initial state. This reset function is added to a global set `storeResetFns`.

After each test run, all stores are reset to their initial state using the reset functions stored in `storeResetFns`. This is done in the `afterEach` block.

In the `tests/setup.ts` file, Zustand is mocked using the `vi.mock('zustand')` function.

A new file `__mocks__/vitest-env.d.ts` is added to include type definitions for Vite and Vitest.

