### PR TITLE
Add missing desktop styling elements

### DIFF
--- a/src/components/CartControls.tsx
+++ b/src/components/CartControls.tsx
@@ -26,26 +26,39 @@ function CartControls({ className }: CartControlsProps) {
   return (
     <div
       className={cn(
-        'flex flex-row items-center justify-between rounded-[10px] bg-[#F6F8FD] py-5',
+        'flex h-full min-h-14 flex-row items-center justify-between rounded-[10px] bg-[#F6F8FD]',
         className
       )}
     >
       <button
+        type="button"
         aria-label="Decrement quantity"
         onClick={() => adjustQuantity('decrement')}
-        className="pl-6 text-sunshine-fg"
+        className="relative h-full flex-grow text-sunshine-fg"
       >
-        <img src={iconMinus} alt="-" />
+        <img
+          src={iconMinus}
+          alt="-"
+          className="absolute left-6 top-1/2 -translate-y-1/2"
+        />
       </button>
-      <span className="font-bold" aria-label="Current quantity to add to cart">
+      <span
+        className="w-min flex-shrink-0 font-bold"
+        aria-label="Current quantity to add to cart"
+      >
         {quantity}
       </span>
       <button
+        type="button"
         aria-label="Increment quantity"
         onClick={() => adjustQuantity('increment')}
-        className="pr-6 text-sunshine-fg"
+        className="relative h-full flex-grow pr-6 text-sunshine-fg"
       >
-        <img src={iconPlus} alt="+" />
+        <img
+          src={iconPlus}
+          alt="+"
+          className="absolute right-6 top-1/2 -translate-y-1/2"
+        />
       </button>
     </div>
   )

--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -1,11 +1,13 @@
-import productImg1 from '@/assets/products/image-product-1.jpg'
-import productImg2 from '@/assets/products/image-product-2.jpg'
-import productImg3 from '@/assets/products/image-product-3.jpg'
-import productImg4 from '@/assets/products/image-product-4.jpg'
 import product1Thumb from '@/assets/products/image-product-1-thumbnail.jpg'
+import productImg1 from '@/assets/products/image-product-1.jpg'
 import product2Thumb from '@/assets/products/image-product-2-thumbnail.jpg'
+import productImg2 from '@/assets/products/image-product-2.jpg'
 import product3Thumb from '@/assets/products/image-product-3-thumbnail.jpg'
+import productImg3 from '@/assets/products/image-product-3.jpg'
 import product4Thumb from '@/assets/products/image-product-4-thumbnail.jpg'
+import productImg4 from '@/assets/products/image-product-4.jpg'
+import { cn } from '@/utils'
+import { useState } from 'react'
 
 /**
  * Renders a desktop product gallery component with a large main image and thumbnail previews.
@@ -14,6 +16,8 @@ import product4Thumb from '@/assets/products/image-product-4-thumbnail.jpg'
  * - Images require a source, thumbnail source, and alt text.
  */
 export function DesktopProductGallery() {
+  const [selectedImg, setSelectedImg] = useState(0)
+
   const productImgs = [
     {
       src: productImg1,
@@ -40,19 +44,32 @@ export function DesktopProductGallery() {
   return (
     <section className="w-full">
       <img
-        src={productImgs[0].src}
-        alt={productImgs[0].alt}
+        src={productImgs[selectedImg].src}
+        alt={productImgs[selectedImg].alt}
         className="aspect-square w-full rounded-2xl"
       />
 
       <div className="mt-8 flex w-full flex-row items-center justify-between gap-8">
         {productImgs.map(({ thumbSrc, alt }, i) => (
-          <img
-            src={thumbSrc}
-            alt={alt}
-            className="aspect-square min-w-0 flex-1 rounded-[10px]"
+          <button
+            onClick={() => setSelectedImg(i)}
+            className={cn('rounded-[10px] border-2 border-transparent', {
+              'border-sunshine-fg': i === selectedImg,
+            })}
             key={i}
-          />
+          >
+            <img
+              src={thumbSrc}
+              alt={alt}
+              className={cn(
+                'aspect-square min-w-0 flex-1 rounded-[10px]',
+                {
+                  'rounded-[8px] opacity-50': i === selectedImg,
+                },
+                'hover:opacity-50'
+              )}
+            />
+          </button>
         ))}
       </div>
     </section>

--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -59,6 +59,7 @@ export function DesktopProductGallery() {
             key={i}
           >
             <img
+              role="thumbnail"
               src={thumbSrc}
               alt={alt}
               className={cn(

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -50,21 +50,11 @@ export function DesktopTopBar() {
         <img src={logo} alt="logo" aria-label="sneakers" className="" />
 
         <ul className="flex flex-row gap-8 text-black-lighter">
-          <li>
-            <a href="/">Collections</a>
-          </li>
-          <li>
-            <a href="/">Men</a>
-          </li>
-          <li>
-            <a href="/">Women</a>
-          </li>
-          <li>
-            <a href="/">About</a>
-          </li>
-          <li>
-            <a href="/">Contact</a>
-          </li>
+          {['Collections', 'Men', 'Women', 'About', 'Contact'].map((label) => (
+            <li key={label}>
+              <a href="/">{label}</a>
+            </li>
+          ))}
         </ul>
       </nav>
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -66,7 +66,11 @@ export function DesktopTopBar() {
         <TopBarCart />
 
         {/* Avatar/Your Account */}
-        <img src={avatar} alt="Your account" className="h-12 w-12" />
+        <img
+          src={avatar}
+          alt="Your account"
+          className="h-12 w-12 rounded-full border-2 border-transparent hover:cursor-pointer hover:border-sunshine-fg"
+        />
       </div>
     </div>
   )

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -42,16 +42,19 @@ export function DesktopTopBar() {
   return (
     <div
       id="top-bar" // ID needed for TopBarCart to correctly position cart icon
-      className="flex w-full flex-row justify-between border-b-[1px] border-b-[#E4E9F2] px-4 py-8"
+      className="flex w-full flex-row justify-between border-b-[1px] border-b-[#E4E9F2] px-4"
     >
       {/* Left hand side of TopBar */}
       <nav className="flex items-center gap-14">
         {/* Logo */}
         <img src={logo} alt="logo" aria-label="sneakers" className="" />
 
-        <ul className="flex flex-row gap-8 text-black-lighter">
+        <ul className="flex h-full flex-row gap-8 text-black-lighter">
           {['Collections', 'Men', 'Women', 'About', 'Contact'].map((label) => (
-            <li key={label}>
+            <li
+              key={label}
+              className="h-full border-b-4 border-sunshine-fg border-transparent pb-9 pt-10 hover:border-sunshine-fg"
+            >
               <a href="/">{label}</a>
             </li>
           ))}


### PR DESCRIPTION
Adds styling on the desktop view that is on the design but not yet live on the webpage:

- Add hover orange bottom borders to nav links
- Add hover orange border on profile picture
- Make image selection in desktop ProductGallery functional

## Bonus

- Increase the clickable area of the `-` and `+` buttons on CartControls